### PR TITLE
Fixed many warnings/errors & other enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 /code/.idea/
 */__pycache__
 .DS_Store
+dataset/*
+experiment/
+infer_results/
+inference_results_log/
+paper/
+pretrain_models/
+*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,3 @@
 /code/.idea/
 */__pycache__
 .DS_Store
-dataset/*
-experiment/
-infer_results/
-inference_results_log/
-paper/
-pretrain_models/
-*.pyc

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ python inference.py --data_path path/to/data --model_path path/to/pretrained/mod
     howpublished = {\url{https://github.com/csbhr/CDVD-TSP}}
 }
 ```
-### Citation 2
+### Citation 3
 ```
 @misc{pytorch-pwc,
     author = {Simon Niklaus},

--- a/README.md
+++ b/README.md
@@ -11,23 +11,21 @@ By [Jinshan Pan](https://jspan.github.io/), [Haoran Bai](https://csbhr.github.io
 ## Updates
 [2021-05-23] Many improvements to code.
 - Several warnings and errors were addressed
-  - Issues Fixed [#12](https://github.com/csbhr/CDVD-TSP/issues/12),
-  [#22](https://github.com/csbhr/CDVD-TSP/issues/22),
-  [#24](https://github.com/csbhr/CDVD-TSP/issues/24),
-  [#26](https://github.com/csbhr/CDVD-TSP/issues/26)
+  - Issues Fixed [#12](https://github.com/csbhr/CDVD-TSP/issues/12), [#22](https://github.com/csbhr/CDVD-TSP/issues/22), [#24](https://github.com/csbhr/CDVD-TSP/issues/24), [#26](https://github.com/csbhr/CDVD-TSP/issues/26)
   - PyTorch 1.8.1, Python 3.8, & Cuda 10.2 has been tested
   - PyTorch 0.4.1, Python 3.7, & Cuda 9.2 should still work
     - However, this hasn't been verified for due to test computer unable to run Cuda 9.2
     - It appears that the graphics card is too new for Cuda 9.2
+  - Inference no longer requires gt images [#12](https://github.com/csbhr/CDVD-TSP/issues/12), [#22](https://github.com/csbhr/CDVD-TSP/issues/22), [#26](https://github.com/csbhr/CDVD-TSP/issues/26)
   - Added `if __name__ == '__main__':` to `main.py` to resolve [#24](https://github.com/csbhr/CDVD-TSP/issues/24)
   - `optimizer.step()` was added prior to `lr_scheduler.step()`
     - Failure to do this will result in PyTorch skipping the first value of the learning rate schedule. See more details [Here](https://pytorch.org/docs/stable/optim.html#how-to-adjust-learning-rate)
-  - Added align_corner=True parameter to `nn.functional.grid_sample` in `flow_pwc.py` since that was the behavior for PyTorch 0.4.1.
-    - This behavior was changed in PyTorch 1.3.0 from `True` to `False`
+  - Added align_corners=True parameter to `nn.functional.grid_sample` in `flow_pwc.py` since that was the behavior for PyTorch 0.4.1.
+    - This behavior was changed in PyTorch 1.3.0 from `True` to `False`. See more details [Here](https://github.com/pytorch/pytorch/releases/tag/v1.3.0)
   - Windows cannot have a colon in a filename.
     - Changed filenames with date time from `YYYY-MM-DD hh:mm:ss` to `YYYY-MM-DDThhmmss` per [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
 - Changed `log.txt` and `config.txt` files to have the time added to them so that each new run will have a new file. Especially handy for a `--resume`
-- `n_frames_per_video` increased from 100 to 200 in order to take full advantage of all of training datasets.
+- `n_frames_per_video` increased from 100 to 200 in order to take full advantage of all of the frames in the training datasets.
 - Images are no longer saved by default during test phase of epoch.
   - There was no way to disable with a switch prior to this change
   - Can be enabled with `--save_images` option
@@ -37,7 +35,6 @@ By [Jinshan Pan](https://jspan.github.io/), [Haoran Bai](https://csbhr.github.io
 - PDF plots no longer created during 1st epoch due to lack of data
   - L1, HEM, & Total Loss plots are now combined in one plot instead of 3
   - PSNR plot no longer has a legend since it was blank
-- Inference no longer requires gt images
 - Inference will handle border situations like this
   - For a video with 5 frames [1, 2, 3, 4, 5] it will use a list of frames [3, 2, 1, 2, 3, 4, 5, 4, 3]
   - Previous handling of the same clip would produce a singe frame [3]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ By [Jinshan Pan](https://jspan.github.io/), [Haoran Bai](https://csbhr.github.io
   - Issues Fixed [#12](https://github.com/csbhr/CDVD-TSP/issues/12), [#22](https://github.com/csbhr/CDVD-TSP/issues/22), [#24](https://github.com/csbhr/CDVD-TSP/issues/24), [#26](https://github.com/csbhr/CDVD-TSP/issues/26)
   - PyTorch 1.8.1, Python 3.8, & Cuda 10.2 has been tested
   - PyTorch 0.4.1, Python 3.7, & Cuda 9.2 should still work
-    - However, this hasn't been verified for due to test computer unable to run Cuda 9.2
+    - However, this hasn't been verified due to test computer unable to run Cuda 9.2
     - It appears that the graphics card is too new for Cuda 9.2
   - Inference no longer requires gt images [#12](https://github.com/csbhr/CDVD-TSP/issues/12), [#22](https://github.com/csbhr/CDVD-TSP/issues/22), [#26](https://github.com/csbhr/CDVD-TSP/issues/26)
   - Added `if __name__ == '__main__':` to `main.py` to resolve [#24](https://github.com/csbhr/CDVD-TSP/issues/24)

--- a/README.md
+++ b/README.md
@@ -5,10 +5,44 @@
 [![PyTorch](https://img.shields.io/badge/pytorch-0.4.1-%237732a8)](https://pytorch.org/)
 
 #### [Paper](https://arxiv.org/abs/2004.02501) | [Project Page](https://csbhr.github.io/projects/cdvd-tsp/index.html) | [Discussion](https://github.com/csbhr/CDVD-TSP/issues)
-### Cascaded Deep Video Deblurring Using Temporal Sharpness Prior
+### Cascaded Deep Video Deblurring Using Temporal Sharpness Prior[[1](#user-content-citation-1)]
 By [Jinshan Pan](https://jspan.github.io/), [Haoran Bai](https://csbhr.github.io/about), and Jinhui Tang
 
 ## Updates
+[2021-05-23] Many improvements to code.
+- Several warnings and errors were addressed
+  - Issues Fixed [#12](https://github.com/csbhr/CDVD-TSP/issues/12),
+  [#22](https://github.com/csbhr/CDVD-TSP/issues/22),
+  [#24](https://github.com/csbhr/CDVD-TSP/issues/24),
+  [#26](https://github.com/csbhr/CDVD-TSP/issues/26)
+  - PyTorch 1.8.1, Python 3.8, & Cuda 10.2 has been tested
+  - PyTorch 0.4.1, Python 3.7, & Cuda 9.2 should still work
+    - However, this hasn't been verified for due to test computer unable to run Cuda 9.2
+    - It appears that the graphics card is too new for Cuda 9.2
+  - Added `if __name__ == '__main__':` to `main.py` to resolve [#24](https://github.com/csbhr/CDVD-TSP/issues/24)
+  - `optimizer.step()` was added prior to `lr_scheduler.step()`
+    - Failure to do this will result in PyTorch skipping the first value of the learning rate schedule. See more details [Here](https://pytorch.org/docs/stable/optim.html#how-to-adjust-learning-rate)
+  - Added align_corner=True parameter to `nn.functional.grid_sample` in `flow_pwc.py` since that was the behavior for PyTorch 0.4.1.
+    - This behavior was changed in PyTorch 1.3.0 from `True` to `False`
+  - Windows cannot have a colon in a filename.
+    - Changed filenames with date time from `YYYY-MM-DD hh:mm:ss` to `YYYY-MM-DDThhmmss` per [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+- Changed `log.txt` and `config.txt` files to have the time added to them so that each new run will have a new file. Especially handy for a `--resume`
+- `n_frames_per_video` increased from 100 to 200 in order to take full advantage of all of training datasets.
+- Images are no longer saved by default during test phase of epoch.
+  - There was no way to disable with a switch prior to this change
+  - Can be enabled with `--save_images` option
+- Now gives an estimate of completion time for the current epoch and all epochs
+  - 1st training session estimate does not include the 1st test session duration for the 1st epoch.
+  - When using `--resume --load`, start time will be recalculated based on the prior elapsed times
+- PDF plots no longer created during 1st epoch due to lack of data
+  - L1, HEM, & Total Loss plots are now combined in one plot instead of 3
+  - PSNR plot no longer has a legend since it was blank
+- Inference no longer requires gt images
+- Inference will handle border situations like this
+  - For a video with 5 frames [1, 2, 3, 4, 5] it will use a list of frames [3, 2, 1, 2, 3, 4, 5, 4, 3]
+  - Previous handling of the same clip would produce a singe frame [3]
+  - The new result will be frames [1, 2, 3, 4, 5] with all 5 frames being deblurred
+
 [2020-10-22] Inference results on DVD and GOPRO are available [[Here]](https://drive.google.com/drive/folders/1lMpj-fkT89JfMOvTnqXMzfa57zCT8-2s?usp=sharing)!  
 [2020-10-10] Metrics(PSNR/SSIM) calculating codes are available [[Here]](https://github.com/csbhr/OpenUtility#chapter-calculating-metrics)!  
 [2020-08-04] Inference logs are available [[Here]](https://drive.google.com/drive/folders/1lMpj-fkT89JfMOvTnqXMzfa57zCT8-2s?usp=sharing)!  
@@ -33,7 +67,7 @@ More detailed analysis and experimental results are included in [[Project Page]]
 
 ## Dependencies
 
-- We use the implementation of PWC-Net by [[sniklaus/pytorch-pwc]](https://github.com/sniklaus/pytorch-pwc)
+- We use a modified version of the implementation of PWC-Net[[3](#user-content-citation-3)] by [[sniklaus/pytorch-pwc]](https://github.com/sniklaus/pytorch-pwc)
 - Linux (Tested on Ubuntu 18.04)
 - Python 3 (Recommend to use [Anaconda](https://www.anaconda.com/download/#linux))
 - [PyTorch 0.4.1](https://pytorch.org/): `conda install pytorch=0.4.1 torchvision cudatoolkit=9.2 -c pytorch`
@@ -44,12 +78,38 @@ More detailed analysis and experimental results are included in [[Project Page]]
 - skimage: `conda install scikit-image`
 - tqdm: `conda install tqdm`
 - cupy: `conda install -c anaconda cupy`
+### Example for Python 3.7
+```dos
+conda install -y pytorch=0.4.1 torchvision cudatoolkit=9.2 -c pytorch
+conda install -y matplotlib
+conda install -y opencv
+conda install -y imageio
+conda install -y scikit-image
+conda install -y tqdm
+pip install cupy-cuda92
+```
+### Example for Python 3.8
+```dos
+conda install -y pytorch torchvision torchaudio cudatoolkit=10.2 -c pytorch
+conda install -y matplotlib
+conda install -y opencv
+conda install -y imageio
+conda install -y scikit-image
+conda install -y tqdm
+pip install cupy-cuda102
+```
+
 
 ## Get Started
 
 ### Download
 - Pretrained models and Datasets can be downloaded [[Here]](https://drive.google.com/drive/folders/1lw_1jITafEQ9DvMys_S6aYwtNApYKWsz?usp=sharing).
 	- If you have downloaded the pretrained models，please put them to './pretrain_models'.
+      - CDVD_TSP_DVD_Paper.pt pretrained model that was done for the paper using [DeepVideoDeblurring dataset](https://github.com/shuochsu/DeepVideoDeblurring)
+      - CDVD_TSP_GOPRO.pt pretrained model using [GOPRO_Large dataset](https://github.com/SeungjunNah/DeepDeblur_release)
+      - CDVD_TSP_DVD_Convergent.pt pretrained model that continued until convergence
+      - network-default.pytorch pretrained model for PWC-Net[[3](#user-content-citation-3)]
+        - Available from the PyTorch-PWC author and can be downloaded [[Here]](http://content.sniklaus.com/github/pytorch-pwc/network-default.pytorch).
 	- If you have downloaded the datasets，please put them to './dataset'.
 
 ### Dataset Organization Form
@@ -75,18 +135,34 @@ If you prepare your own dataset, please follow the following form:
 ```
 
 ### Training
-- Download the PWC-Net pretrained model.
+- Download the PWC-Net[[3](#user-content-citation-3)] pretrained model.
 - Download training dataset, or prepare your own dataset like above form.
+- Each epoch has a training phase and a testing phase to determine the PSNR and evaluate the results.
 - Run the following commands:
 ```
 cd ./code
-python main.py --save path/to/save --dir_data path/to/train/dataset --dir_data_test path/to/val/dataset --epochs 500 --batch_size 8
-	# --save: the experiment result will be in './experiment/save'.
-	# --dir_data: the path of the training dataset.
-	# --dir_data_test: the path of the evaluating dataset during training process.
-	# --epochs: the number of training epochs.
-	# --batch_size: the mini batch size.
+python main.py --save Experiment_Name --dir_data path/to/train/dataset --dir_data_test path/to/val/dataset --epochs 500 --batch_size 8
+  # --save:          Experiment name to save
+                     The experiment result will be in './experiment/'.
+  # --dir_data:      The path of the training dataset.
+                     Used during the training phase of the epoch.
+  # --dir_data_test: The path of the evaluating dataset during training process.
+                     Used during the testing phase of the epoch.
+  # --epochs:        The number of training epochs.
+  # --batch_size:    The mini batch size.
+  # --print_every:   How many batches to wait before logging training status
+                     during training phase of epoch.
+  # --save_images:   Save images during test phase of epoch.
+  # --load:          Experiment name to load
+                     The experiment result must be in './experiment/'.
+                     Use --resume to continue at the last epoch completed
+  # --resume:        Resume from the latest complete epoch must use --load instead of --save.
 ```
+#### Examples of Training
+`python main.py --save CDVD_TSP_DVD_Convergent --dir_data F:\workspaces\CDVD-TSP\dataset\DVD\train --dir_data_test F:\workspaces\CDVD-TSP\dataset\DVD\test --epochs 1000 --print_every 500 --batch_size 2`
+
+`python main.py --resume --load CDVD_TSP_DVD_Convergent --dir_data F:\workspaces\CDVD-TSP\dataset\DVD\train --dir_data_test F:\workspaces\CDVD-TSP\dataset\DVD\test --epochs 1000 --print_every 500 --batch_size 2`
+
 
 ### Testing
 
@@ -113,13 +189,32 @@ python inference.py --data_path path/to/data --model_path path/to/pretrained/mod
 ```
 - The deblured result will be in './infer_results'.
 
-## Citation
+## Citations
+### Citation 1
 ```
 @InProceedings{Pan_2020_CVPR,
-	author = {Pan, Jinshan and Bai, Haoran and Tang, Jinhui},
-	title = {Cascaded Deep Video Deblurring Using Temporal Sharpness Prior},
-	booktitle = {IEEE/CVF Conference on Computer Vision and Pattern Recognition (CVPR)},
-	month = {June},
-	year = {2020}
+    author = {Pan, Jinshan and Bai, Haoran and Tang, Jinhui},
+    title = {Cascaded Deep Video Deblurring Using Temporal Sharpness Prior},
+    booktitle = {IEEE/CVF Conference on Computer Vision and Pattern Recognition (CVPR)},
+    month = {June},
+    year = {2020}
+}
+```
+### Citation 2
+```
+@misc{CDVD-TSP,
+    author = {Haoran Bai},
+    title = {Cascaded Deep Video Deblurring Using Temporal Sharpness Prior},
+    year = {2020},
+    howpublished = {\url{https://github.com/csbhr/CDVD-TSP}}
+}
+```
+### Citation 2
+```
+@misc{pytorch-pwc,
+    author = {Simon Niklaus},
+    title = {A Reimplementation of {PWC-Net} Using {PyTorch}},
+    year = {2018},
+    howpublished = {\url{https://github.com/sniklaus/pytorch-pwc}}
 }
 ```

--- a/code/inference.py
+++ b/code/inference.py
@@ -42,7 +42,7 @@ class Inference:
         self.GT_path = os.path.join(self.data_path, "gt")
 
         now_time = time.localtime()
-        now_time_file = time.strftime("%Y-%m-%dT%H%M%S%", now_time)
+        now_time_file = time.strftime("%Y-%m-%d", now_time) + "T" + time.strftime("%H%M%S", now_time)
         now_time_log = time.strftime("%Y-%m-%d %H:%M:%S", now_time)
         self.logger = Traverse_Logger(self.result_path, 'inference_log_{}.txt'.format(now_time_file))
 
@@ -74,10 +74,23 @@ class Inference:
                 video_psnr = []
                 video_ssim = []
                 input_frames = sorted(glob.glob(os.path.join(self.input_path, v, "*")))
+                len_frames = len(input_frames)
+                temp_frames = [input_frames[3], input_frames[2]] + input_frames\
+                              + [input_frames[len_frames-1], input_frames[len_frames-2]]
+                input_frames = temp_frames
                 input_seqs = self.gene_seq(input_frames, n_seq=self.n_seq)
                 gt_frames = sorted(glob.glob(os.path.join(self.GT_path, v, "*")))
-                gt_seqs = self.gene_seq(gt_frames, n_seq=self.n_seq)
-                if len(gt_seqs) != 0:
+                del temp_frames
+                del len_frames
+                if len(gt_frames) != 0:
+                    len_frames = len(gt_frames)
+                    temp_frames = [gt_frames[3], gt_frames[2]] + gt_frames\
+                                  + [gt_frames[len_frames-1], gt_frames[len_frames-2]]
+                    gt_frames = temp_frames
+                    gt_seqs = self.gene_seq(gt_frames, n_seq=self.n_seq)
+                    del temp_frames
+                    del len_frames
+
                     for in_seq, gt_seq in zip(input_seqs, gt_seqs):
                         start_time = time.time()
                         filename = os.path.basename(in_seq[self.n_seq // 2]).split('.')[0]

--- a/code/loss/__init__.py
+++ b/code/loss/__init__.py
@@ -98,22 +98,24 @@ class Loss(nn.modules.loss._Loss):
         n_samples = batch + 1
         log = []
         for l, c in zip(self.loss, self.log[-1]):
-            log.append('[{}: {:.4f}]'.format(l['type'], c / n_samples))
+            log.append('[{}: {:.6f}]'.format(l['type'], c / n_samples))
 
         return ''.join(log)
 
     def plot_loss(self, apath, epoch):
-        axis = np.linspace(1, epoch, epoch)
-        for i, l in enumerate(self.loss):
-            label = '{} Loss'.format(l['type'])
+        if epoch > 1:
+            axis = np.linspace(1, epoch, epoch)
             fig = plt.figure()
-            plt.title(label)
-            plt.plot(axis, self.log[:, i].numpy(), label=label)
+            plt.title('L1 & HEM Loss')
+            for i, l in enumerate(self.loss):
+                label = '{} Loss'.format(l['type'])
+                plt.plot(axis, self.log[:, i].numpy(), label=label)
             plt.legend()
             plt.xlabel('Epochs')
             plt.ylabel('Loss')
             plt.grid(True)
-            plt.savefig('{}/loss_loss_{}.pdf'.format(apath, l['type']))
+            #plt.savefig('{}/loss_loss_{}.pdf'.format(apath, l['type']))
+            plt.savefig('{}/loss.pdf'.format(apath))
             plt.close(fig)
 
     def get_loss_module(self):

--- a/code/main.py
+++ b/code/main.py
@@ -6,21 +6,38 @@ import loss
 import option
 from trainer.trainer_cdvd_tsp import Trainer_CDVD_TSP
 from logger import logger
+import datetime
+import time
+from datetime import datetime, time as datetime_time, timedelta
 
-args = option.args
-torch.manual_seed(args.seed)
-chkp = logger.Logger(args)
+def time_diff(start, end):
+    if isinstance(start, datetime_time): # convert to datetime
+        assert isinstance(end, datetime_time)
+        start, end = [datetime.combine(datetime.min, t) for t in [start, end]]
+    if start <= end: # e.g., 10:33:26-11:15:49
+        return end - start
+    else: # end < start e.g., 23:55:00-00:25:00
+        end += timedelta(1) # +day
+        assert end > start
+        return end - start
 
-if args.task == 'VideoDeblur':
-    print("Selected task: {}".format(args.task))
-    model = model.Model(args, chkp)
-    loss = loss.Loss(args, chkp) if not args.test_only else None
-    loader = data.Data(args)
-    t = Trainer_CDVD_TSP(args, loader, model, loss, chkp)
-    while not t.terminate():
-        t.train()
-        t.test()
-else:
-    raise NotImplementedError('Task [{:s}] is not found'.format(args.task))
+if __name__ == '__main__':
+    args = option.args
+    torch.manual_seed(args.seed)
+    chkp = logger.Logger(args)
 
-chkp.done()
+    if args.task == 'VideoDeblur':
+        print("Selected task: {}".format(args.task))
+        model = model.Model(args, chkp)
+        loss = loss.Loss(args, chkp) if not args.test_only else None
+        loader = data.Data(args)
+        t = Trainer_CDVD_TSP(args, loader, model, loss, chkp)
+        start_time = args.start_time
+        print("Start time: {}".format(args.start_time.strftime("%Y-%m-%d %H:%M:%S")))
+        while not t.terminate():
+            t.train()
+            t.test()
+    else:
+        raise NotImplementedError('Task [{:s}] is not found'.format(args.task))
+
+    chkp.done()

--- a/code/model/__init__.py
+++ b/code/model/__init__.py
@@ -76,6 +76,7 @@ class Model(nn.Module):
                 torch.load(os.path.join(apath, 'model', 'model_latest.pt'), **kwargs),
                 strict=False
             )
+            self.args.load = self.args.save
         elif self.args.test_only:
             self.get_model().load_state_dict(
                 torch.load(os.path.join(apath, 'model', 'model_best.pt'), **kwargs),

--- a/code/model/cdvd_tsp.py
+++ b/code/model/cdvd_tsp.py
@@ -73,7 +73,7 @@ class CDVD_TSP(nn.Module):
     def forward(self, x):
         frame_list = [x[:, i, :, :, :] for i in range(self.n_sequence)]
 
-        # Interation 1
+        # Iteration 1
         warped01, _, _, flow_mask01 = self.flow_net(frame_list[1], frame_list[0])
         warped21, _, _, flow_mask21 = self.flow_net(frame_list[1], frame_list[2])
         warped12, _, _, flow_mask12 = self.flow_net(frame_list[2], frame_list[1])
@@ -100,7 +100,7 @@ class CDVD_TSP(nn.Module):
         concated = torch.cat([warped23, frame_list[3], warped43, luckiness], dim=1)
         recons_3, _ = self.recons_net(concated)
 
-        # Interation 2
+        # Iteration 2
         warped_recons12, _, _, flow_mask_recons12 = self.flow_net(recons_2, recons_1)
         warped_recons32, _, _, flow_mask_recons32 = self.flow_net(recons_2, recons_3)
         frame_warp_list = [warped_recons12, recons_2, warped_recons32]

--- a/code/option/__init__.py
+++ b/code/option/__init__.py
@@ -80,17 +80,17 @@ parser.add_argument('--experiment_dir', type=str, default='../experiment/',
 parser.add_argument('--pretrain_models_dir', type=str, default='../pretrain_models/',
                     help='file name to save')
 parser.add_argument('--save', type=str, default='CDVD_TSP_Video_Deblur',
-                    help='file name to save')
+                    help='experiment name to save')
 parser.add_argument('--save_middle_models', action='store_true',
                     help='save all intermediate models')
 parser.add_argument('--load', type=str, default='.',
-                    help='file name to load')
+                    help='experiment name to load')
 parser.add_argument('--resume', action='store_true',
-                    help='resume from the latest if true')
+                    help='resume from the latest complete epoch')
 parser.add_argument('--print_every', type=int, default=100,
                     help='how many batches to wait before logging training status')
-parser.add_argument('--save_images', default=True, action='store_true',
-                    help='save images')
+parser.add_argument('--save_images', action='store_true',
+                    help='save images during test phase of epoch')
 
 args = parser.parse_args()
 template.set_template(args)

--- a/code/option/template.py
+++ b/code/option/template.py
@@ -1,14 +1,20 @@
+from datetime import datetime
+
 def set_template(args):
     if args.template == 'CDVD_TSP':
         args.task = "VideoDeblur"
         args.model = "CDVD_TSP"
         args.n_sequence = 5
-        args.n_frames_per_video = 100
+        args.n_frames_per_video = 200
         args.n_feat = 32
         args.n_resblock = 3
         args.size_must_mode = 4
         args.loss = '1*L1+2*HEM'
         args.lr = 1e-4
         args.lr_decay = 200
+        args.start_time = datetime.now()
+        args.total_train_time = datetime.now() - datetime.now()
+        args.total_test_time = datetime.now() - datetime.now()
+        args.epochs_completed = 0
     else:
         raise NotImplementedError('Template [{:s}] is not found'.format(args.template))

--- a/code/trainer/trainer_cdvd_tsp.py
+++ b/code/trainer/trainer_cdvd_tsp.py
@@ -1,68 +1,128 @@
+"""This is used to train."""
 import decimal
 import torch
 import torch.optim as optim
 from tqdm import tqdm
 from utils import utils
 from trainer.trainer import Trainer
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
 
+def time_diff(t_a, t_b):
+    t_diff = relativedelta(t_b, t_a)  # later/end time comes first!
+    return '{:02d}:{:02d}:{:02d}'.format(t_diff.hours, t_diff.minutes, t_diff.seconds)
 
 class Trainer_CDVD_TSP(Trainer):
     def __init__(self, args, loader, my_model, my_loss, ckp):
-        super(Trainer_CDVD_TSP, self).__init__(args, loader, my_model, my_loss, ckp)
+        super(Trainer_CDVD_TSP, self).__init__(
+            args, loader, my_model, my_loss, ckp)
         print("Using Trainer-CDVD-TSP")
         assert args.n_sequence == 5, \
-            "Only support args.n_sequence=5; but get args.n_sequence={}".format(args.n_sequence)
+            "Only support args.n_sequence=5; but get args.n_sequence={}".format(
+                args.n_sequence)
 
-    def make_optimizer(self):
-        kwargs = {'lr': self.args.lr, 'weight_decay': self.args.weight_decay}
-        return optim.Adam([{"params": self.model.get_model().recons_net.parameters()},
-                           {"params": self.model.get_model().flow_net.parameters(), "lr": 1e-6}],
-                          **kwargs)
+    #def make_optimizer(self):
+    #    kwargs = {'lr': self.args.lr, 'weight_decay': self.args.weight_decay}
+    #    return optim.Adam([{"params": self.model.get_model().recons_net.parameters()},
+    #                       {"params": self.model.get_model().flow_net.parameters(), "lr": 1e-6}],
+    #                      **kwargs)
 
     def train(self):
         print("Now training")
+        # Starting with PyTorch 1.1.0 and later optimizer.step() must be called before scheduler.step()
+        self.optimizer.step()
         self.scheduler.step()
         self.loss.step()
-        epoch = self.scheduler.last_epoch + 1
-        lr = self.scheduler.get_lr()[0]
-        self.ckp.write_log('Epoch {:3d} with Lr {:.2e}'.format(epoch, decimal.Decimal(lr)))
+        epoch = self.scheduler.last_epoch
+        job_epochs_completed = self.args.epochs_completed
+        job_epochs_started = job_epochs_completed + 1
+        job_total_epochs = self.args.epochs - (epoch - job_epochs_started)
+        train_start_time = datetime.now()
+        batch_start_time = datetime.now()
+
+        # get_lr was deprecated starting with PyTorch 1.4.0
+        try:
+            lr = self.scheduler.get_last_lr()[0]
+        except:        
+            lr = self.scheduler.get_lr()[0]
+
+        self.ckp.write_log('\tEpoch {:4d} with Lr {:.2e} started at {}'.format(
+            epoch,
+            decimal.Decimal(lr),
+            train_start_time.strftime("%Y-%m-%d %H:%M:%S")))
         self.loss.start_log()
         self.model.train()
         self.ckp.start_log()
         mid_loss_sum = 0.
+        self.ckp.write_log('\t\t[L1:     Mean Absolute Error(L1 Loss)         ]')
+        self.ckp.write_log('\t\t[HEM:    Hard Example Mining                  ]')
+        self.ckp.write_log('\t\t[Total:  L1+HEM                               ]')
+        self.ckp.write_log('\t\t[now:    Current Time                         ]')
+        self.ckp.write_log('\t\t[CeFin:  Estimated Completion of Current epoch]')
+        self.ckp.write_log('\t\t[AeFin:  Estimated Completion of all epochs   ]')
 
         for batch, (input, gt, _) in enumerate(self.loader_train):
 
             input = input.to(self.device)
             gt_list = [gt[:, i, :, :, :] for i in range(self.args.n_sequence)]
-            gt = torch.cat([gt_list[1], gt_list[2], gt_list[3], gt_list[2]], dim=1).to(self.device)
+            gt = torch.cat([gt_list[1], gt_list[2], gt_list[3],
+                           gt_list[2]], dim=1).to(self.device)
 
-            recons_1, recons_2, recons_3, recons_2_iter, mid_loss = self.model(input)
-            output = torch.cat([recons_1, recons_2, recons_3, recons_2_iter], dim=1)
+            recons_1, recons_2, recons_3, recons_2_iter, mid_loss = self.model(
+                input)
+            output = torch.cat(
+                [recons_1, recons_2, recons_3, recons_2_iter], dim=1)
 
             self.optimizer.zero_grad()
             loss = self.loss(output, gt)
-            if mid_loss:  # mid loss is the loss during the model
-                loss = loss + self.args.mid_loss_weight * mid_loss
-                mid_loss_sum = mid_loss_sum + mid_loss.item()
+            # mid_loss is not set. This does not appear to have been implemented.
+            #if mid_loss:  # mid loss is the loss during the model
+            #    loss = loss + self.args.mid_loss_weight * mid_loss
+            #    mid_loss_sum = mid_loss_sum + mid_loss.item()
             loss.backward()
             self.optimizer.step()
 
             self.ckp.report_log(loss.item())
+            
 
             if (batch + 1) % self.args.print_every == 0:
-                self.ckp.write_log('[{}/{}]\tLoss : [total: {:.4f}]{}[mid: {:.4f}]'.format(
-                    (batch + 1) * self.args.batch_size,
-                    len(self.loader_train.dataset),
-                    self.ckp.loss_log[-1] / (batch + 1),
-                    self.loss.display_loss(batch),
-                    mid_loss_sum / (batch + 1)
-                ))
+                current_time = datetime.now()
+                elapsed_time = current_time - train_start_time
+                frames_completed = (batch + 1) * self.args.batch_size
+                frames_total = len(self.loader_train.dataset)
+                train_end_time = train_start_time + (frames_total * (elapsed_time / frames_completed))
+                epoch_end_time = train_end_time
 
+                if job_epochs_completed > 0:
+                    job_total_time = self.args.total_train_time + self.args.total_test_time
+                    epoch_end_time += self.args.total_test_time/job_epochs_completed
+                    job_end_time = self.args.start_time + (job_total_epochs * (job_total_time/job_epochs_completed))
+                    job_end_time += epoch_end_time - train_start_time
+                    
+                else:
+                    job_end_time = self.args.start_time + (train_end_time - train_start_time)*job_total_epochs
+
+                # Etienne66 Cleaned up by removing unnecessary fields mid was never utilized and 
+                # the total is already included in the display_loss.
+                self.ckp.write_log('[{}/{}]\tLoss : {}[now: {}][CeFin: {}][AeFin: {}]'.format(
+                    frames_completed,
+                    frames_total,
+                    self.loss.display_loss(batch),
+                    current_time.strftime("%H:%M:%S"),
+                    epoch_end_time.strftime("%Y-%m-%d %H:%M:%S"),
+                    job_end_time.strftime("%Y-%m-%d %H:%M:%S")
+                ))
+                batch_start_time = datetime.now()
+
+        self.args.epochs_completed += 1
         self.loss.end_log(len(self.loader_train))
+        self.args.total_train_time += (datetime.now() - train_start_time)
 
     def test(self):
-        epoch = self.scheduler.last_epoch + 1
+        epoch = self.scheduler.last_epoch
+        self.ckp.write_log('Now testing')
+        self.ckp.write_log('\tTest Epoch {:3d}'.format(epoch))
+        test_start_time = datetime.now()
         self.ckp.write_log('\nEvaluation:')
         self.model.eval()
         self.ckp.start_log(train=False)
@@ -78,28 +138,34 @@ class Trainer_CDVD_TSP(Trainer):
                 input_center = input[:, self.args.n_sequence // 2, :, :, :]
                 gt = gt[:, self.args.n_sequence // 2, :, :, :].to(self.device)
 
-                recons_1, recons_2, recons_3, recons_2_iter, _ = self.model(input)
+                recons_1, recons_2, recons_3, recons_2_iter, _ = self.model(
+                    input)
 
-                PSNR_iter1 = utils.calc_psnr(gt, recons_2, rgb_range=self.args.rgb_range)
+                PSNR_iter1 = utils.calc_psnr(
+                    gt, recons_2, rgb_range=self.args.rgb_range)
                 total_PSNR_iter1 += PSNR_iter1
                 total_num += 1
-                PSNR = utils.calc_psnr(gt, recons_2_iter, rgb_range=self.args.rgb_range)
+                PSNR = utils.calc_psnr(
+                    gt, recons_2_iter, rgb_range=self.args.rgb_range)
                 self.ckp.report_log(PSNR, train=False)
 
                 if self.args.save_images:
-                    gt, input_center, recons_2, recons_2_iter = utils.postprocess(gt, input_center, recons_2,
-                                                                                  recons_2_iter,
-                                                                                  rgb_range=self.args.rgb_range,
-                                                                                  ycbcr_flag=False, device=self.device)
+                    gt, input_center, recons_2, recons_2_iter = \
+                        utils.postprocess(gt, input_center, recons_2,
+                                          recons_2_iter,
+                                          rgb_range=self.args.rgb_range,
+                                          ycbcr_flag=False, device=self.device)
                     save_list = [gt, input_center, recons_2, recons_2_iter]
                     self.ckp.save_images(filename, save_list, epoch)
 
             self.ckp.end_log(len(self.loader_test), train=False)
             best = self.ckp.psnr_log.max(0)
-            self.ckp.write_log('[{}]\taverage PSNR_iter1: {:.3f} PSNR_iter2: {:.3f} (Best: {:.3f} @epoch {})'.format(
-                self.args.data_test,
-                total_PSNR_iter1 / total_num,
-                self.ckp.psnr_log[-1],
-                best[0], best[1] + 1))
+            self.ckp.write_log('[{}]\taverage PSNR_iter1: {:.3f} PSNR_iter2: {:.3f} '\
+                               '(Best: {:.3f} @epoch {})'.format(self.args.data_test,
+                                                                 total_PSNR_iter1 / total_num,
+                                                                 self.ckp.psnr_log[-1],
+                                                                 best[0], best[1] + 1))
+            self.args.total_test_time += datetime.now() - test_start_time
+
             if not self.args.test_only:
                 self.ckp.save(self, epoch, is_best=(best[1] + 1 == epoch))


### PR DESCRIPTION
- Several warnings and errors were addressed
  - Issues Fixed #12, #22, #24, #26
  - PyTorch 1.8.1, Python 3.8, & Cuda 10.2 has been tested
  - PyTorch 0.4.1, Python 3.7, & Cuda 9.2 should still work
    - However, this hasn't been verified due to test computer unable to run Cuda 9.2
    - It appears that the graphics card is too new for Cuda 9.2
  - Inference no longer requires gt images #12, #22, #26
  - Added `if __name__ == '__main__':` to `main.py` to resolve #24 
  - `optimizer.step()` was added prior to `lr_scheduler.step()`
    - Failure to do this will result in PyTorch skipping the first value of the learning rate schedule. See more details [Here](https://pytorch.org/docs/stable/optim.html#how-to-adjust-learning-rate)
  - Added align_corners=True parameter to `nn.functional.grid_sample` in `flow_pwc.py` since that was the behavior for PyTorch 0.4.1.
    - This behavior was changed in PyTorch 1.3.0 from `True` to `False`. See more details [Here](https://github.com/pytorch/pytorch/releases/tag/v1.3.0)
  - Windows cannot have a colon in a filename.
    - Changed filenames with date time from `YYYY-MM-DD hh:mm:ss` to `YYYY-MM-DDThhmmss` per [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
- Changed `log.txt` and `config.txt` files to have the time added to them so that each new run will have a new file. Especially handy for a `--resume`
- `n_frames_per_video` increased from 100 to 200 in order to take full advantage of all of the frames in the training datasets.
- Images are no longer saved by default during test phase of epoch.
  - There was no way to disable with a switch prior to this change
  - Can be enabled with `--save_images` option
- Now gives an estimate of completion time for the current epoch and all epochs
  - 1st training session estimate does not include the 1st test session duration for the 1st epoch.
  - When using `--resume --load`, start time will be recalculated based on the prior elapsed times
- PDF plots no longer created during 1st epoch due to lack of data
  - L1, HEM, & Total Loss plots are now combined in one plot instead of 3
  - PSNR plot no longer has a legend since it was blank
- Inference will handle border situations like this
  - For a video with 5 frames [1, 2, 3, 4, 5] it will use a list of frames [3, 2, 1, 2, 3, 4, 5, 4, 3]
  - Previous handling of the same clip would produce a singe frame [3]
  - The new result will be frames [1, 2, 3, 4, 5] with all 5 frames being deblurred